### PR TITLE
possible improvement: roomComparison

### DIFF
--- a/SaltyChat.Client/source/Dumps/RoomCombinations.ts
+++ b/SaltyChat.Client/source/Dumps/RoomCombinations.ts
@@ -1,0 +1,44 @@
+export const RoomCombinations = [
+    // Vanilla Unicorn
+    {
+        "unicorn_Mainstage": 131980810,
+        "unicorn_Lounge": 195855361
+    },
+    {
+        "unicorn_Entry": 406005291,
+        "unicorn_EntryFloor": 1794777727
+    },
+    {
+        "unicorn_PrivateArea_Walk": 325607281,
+        "unicorn_PrivateArea": 2661529753
+    },
+    {
+        "unicorn_LockerArea": 336696765,
+        "unicorn_LockerArea_Wall": 3874670385
+    },
+    // Yellow Jack In
+    {
+        "yellowjackin_BarArea": 441988381,
+        "yellowjackin_CustomerArea": 3718785313
+    },
+    // Tequilala
+    {
+        "tequilala_Entry_Area": 3070346248,
+        "tequilala_EntryFloor_Area": 209242346,
+        "tequilala_Entry_Clothing": 2699110422
+    },
+    {
+        "tequilala_DownStairs": 291590403,
+        "tequilala_DownStairsArea": 2635531210
+    },
+    {
+        "tequilala_MainArea": 1921450756,
+        "tequilala_MainArea_FirstFloor_Stairs": 2526696518,
+        "tequilala_MainArea_FirstFloor_Stairs_Area": 593969979,
+        "tequilala_MainArea_FirstFloor_Area": 182753347
+    },
+    {
+        "tequilala_SencondFloor_Stairs": 1532913744,
+        "tequilala_SencondFloor_Stairs_Floor": 4193595779
+    },
+];

--- a/SaltyChat.Client/source/Helpers/RoomComparison.ts
+++ b/SaltyChat.Client/source/Helpers/RoomComparison.ts
@@ -1,0 +1,36 @@
+import { Player} from "alt-client";
+import { getRoomKeyFromEntity, hasEntityClearLosToEntity } from "natives";
+import { RoomCombinations } from '../Dumps/RoomCombinations'
+
+/**
+ * Compares the roomId of the local player with the roomId of another player and determines the voice compensation factor
+ * @param oPlayer Object of the other player
+ * @returns {} Returns the muffle index of the player, or null if the player is not in a room
+ */
+export function roomComparison(oPlayer: Player) {
+    let roomIdPlayer = getRoomKeyFromEntity(Player.local.scriptID);
+    let roomIdOPlayer = getRoomKeyFromEntity(oPlayer.scriptID);
+    let roomExtension = RoomCombinations.some(roomPairs => {
+        if (Object.values(roomPairs).indexOf(roomIdPlayer) > -1 &&
+            Object.values(roomPairs).indexOf(roomIdOPlayer) > -1) {
+            return true
+        } else { return false;}
+    })
+    
+    // Both players in the same room
+    if (roomIdPlayer == roomIdOPlayer) return null;
+
+    // The room was expanded over the dumps
+    if (roomExtension) return null;
+
+    // Clear view of the other player but possibly glass between them
+    if (hasEntityClearLosToEntity(Player.local.scriptID, oPlayer.scriptID, 17)) return 1;
+
+    // A player stands outside a building of one inside
+    if (roomIdPlayer == 0 && roomIdOPlayer != 0) return 10;
+    if (roomIdOPlayer == 0 && roomIdPlayer != 0) return 10;
+
+    // Both players within one building, but different rooms
+    if (roomIdPlayer != roomIdOPlayer) return 7;
+    return 0;
+}

--- a/SaltyChat.Client/source/app.ts
+++ b/SaltyChat.Client/source/app.ts
@@ -6,6 +6,7 @@ import {Config} from "./config";
 // Helpers
 import {loadAnimDict} from "./Helpers/LoadAnimDict";
 import {hasOpening} from "./Helpers/HasOpening";
+import {roomComparison} from "./Helpers/RoomComparison";
 // Models
 import {BulkUpdate} from "./Models/SaltyChat/BulkUpdate";
 import {Configuration} from "./Models/SaltyChat/Configuration";
@@ -430,9 +431,6 @@ export class SaltyVoice {
     private stateUpdateTick(): void {
         let playerStates = [];
 
-        let localRoomId = native.getRoomKeyFromEntity(alt.Player.local.scriptID);
-        let localScriptId = alt.Player.local.scriptID;
-
         this.VoiceClients.forEach((voiceClient) => {
             let nextPlayer = voiceClient.player;
             if (!nextPlayer.valid) return;
@@ -455,17 +453,12 @@ export class SaltyVoice {
 
                 let muffleIntensity = null;
                 if (Config.enableMuffling) {
-                    let npRoomId = native.getRoomKeyFromEntity(nextPlayer.scriptID);
-
-                    if (localRoomId != npRoomId && !native.hasEntityClearLosToEntity(localScriptId, nextPlayer.scriptID, 17)) {
-                        muffleIntensity = 10;
-                    } else {
-                        let pVehicle = alt.Player.local.vehicle;
-                        let nVehicle = nextPlayer.vehicle;
-                        if (pVehicle != nVehicle) {
-                            if (pVehicle && !hasOpening(pVehicle)) muffleIntensity += 4;
-                            if (nVehicle && !hasOpening(nVehicle)) muffleIntensity += 4;
-                        }
+                    muffleIntensity = roomComparison(nextPlayer)
+                    let pVehicle = alt.Player.local.vehicle;
+                    let nVehicle = nextPlayer.vehicle;
+                    if (pVehicle != nVehicle) {
+                        if (pVehicle && !hasOpening(pVehicle)) muffleIntensity += 4;
+                        if (nVehicle && !hasOpening(nVehicle)) muffleIntensity += 4;
                     }
                 }
 


### PR DESCRIPTION
Possible improvement: 
Room comparison with various gradations of Compensation quality.

Scope of functions: 
1. it is possible to combine several rooms to one big room. Use Case: Rooms which have different Room IDs ( examples in the RoomCombinations.ts )

2. it is distinguished if a player is already in a building or if he is one room further inside the building. Use Case: Vanilla Unicorn: P1 outside of the building. P2 in any room of the building. => `Compensation=10`
P1 in any room of the building. P2 in another room of the building. `Compensation=7`

3. if there are panes in the building, the compensation is limited to 1 depending on 1. and 2. 

You are welcome to redefine or extend the function.  This fork is based on the assumption of the author, `I appreciate any contribution`
