### PR TITLE
Add Client Event for talkingState

### DIFF
--- a/SaltyChat.Client/package.json
+++ b/SaltyChat.Client/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@altv/types-client": "^1.5.2",
     "@altv/types-natives": "^1.1.0",
+    "@altv/types-shared": "^1.1.7",
     "@types/node": "^8.0.14",
     "tsc": "^1.20150623.0",
     "typescript": "^3.2.2"

--- a/SaltyChat.Client/source/Enum/Events/ToClient.ts
+++ b/SaltyChat.Client/source/Enum/Events/ToClient.ts
@@ -1,5 +1,6 @@
 ﻿export enum ToClient {
     radioChanged = "SaltyChat:RadioChanged",
     stateChanged = "SaltyChat:StateChanged",
-    voiceRangeChanged = "SaltyChat:VoiceRangeChanged"
+    voiceRangeChanged = "SaltyChat:VoiceRangeChanged",
+    voiceTalkingChanged = "SaltyChat:VoiceTalkingChanged"
 }

--- a/SaltyChat.Client/source/app.ts
+++ b/SaltyChat.Client/source/app.ts
@@ -743,6 +743,13 @@ export class SaltyVoice {
           'facials@gen_male@variations@normal'
         );
     }
+
+    if (
+      teamSpeakName == this._configuration.teamSpeakName &&
+      Config.enableTalkingChangedEvent
+    ) {
+      alt.emit(ToClient.voiceTalkingChanged, isTalking);
+    }
   }
 
   private initializePlugin(): void {

--- a/SaltyChat.Client/source/config.ts
+++ b/SaltyChat.Client/source/config.ts
@@ -11,4 +11,5 @@ export class Config {
     public static overlayLanguage: string = "en";
     public static overlayAddress: string = "ts.yourserver.com";
     public static automaticPlayerHealth: boolean = true;
+    public static enableTalkingChangedEvent: boolean = false;
 }


### PR DESCRIPTION
Use Case: Display the talking state to the user in the UI of the server gamemode.

The event is disabled by default to keep the default state as it is. Activate it via the client config.

Docs: If the PR is accept I would start another to your docs repo to document the new event in your gitbook.

Question: Should the `node_modules` and `Resource` folder directly be commited or are you doing this just for releases?

Best regards
Daniel